### PR TITLE
Implement tokio support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ task:
     - cargo check --features mio --tests --examples
     - cargo check --features mio-uds --tests --examples
     - cargo check --features mio_07 --tests --examples
+    - cargo check --features tokio --tests --examples
     - cargo build --all-features --tests --examples
   test_script:
     - . $HOME/.cargo/env
@@ -29,9 +30,9 @@ task:
     - rm -rf $HOME/.cargo/registry/index
 
 task:
-  name: Linux amd64 1.36
+  name: Linux amd64 1.39
   container:
-    image: rust:1.36
+    image: rust:1.39
     cpu: 1
     memory: 1
   cargo_cache:
@@ -42,6 +43,7 @@ task:
     - cargo check --features mio
     - cargo check --features mio-uds
     - cargo check --features mio_07
+    - cargo check --features tokio
     - cargo build --all-features
   test_script:
     - cargo run --bin characteristics
@@ -65,11 +67,13 @@ task:
     - cargo build -Z minimal-versions --features mio
     - # no version of mio-uds compiles
     - cargo build -Z minimal-versions --features mio_07
+    - cargo build -Z minimal-versions --features tokio
   test_script:
     - RUST_BACKTRACE=1
     - cargo test -Z minimal-versions --features mio --no-fail-fast -- --test-threads=1
     - export RUSTFLAGS='--cfg features="os-poll"'
     - cargo test -Z minimal-versions --features mio_07 --no-fail-fast -- --test-threads=1
+    - cargo test -Z minimal-versions --features tokio --no-fail-fast -- --test-threads=1
   before_cache_script:
     - rm -rf $HOME/.cargo/registry/index
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
   - cargo check --features mio
   - cargo check --features mio-uds
   - cargo check --features mio_07
+  - cargo check --features tokio
   - export RUSTFLAGS='--cfg features="os-poll"'
   - cargo test --all-features --no-fail-fast
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ mio_07 = {package="mio", version="0.7.0", features=["os-util", "uds"], optional=
 tokio_02 = {package="tokio", version = "0.2", features = ["io-driver"], optional=true}
 
 [target."cfg(unix)".dev-dependencies]
+remove_dir_all = "=0.5.2" # Avoids MSRV bump (Stebalien/tempfile#120)
+tempfile = "3.1"
 tokio_02 = {package="tokio", version = "0.2", features = ["macros", "rt-core"]}
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ categories = ["os::unix-apis", "asynchronous"]
 edition = "2018"
 exclude = ["tests", "src/bin"]
 
+[features]
+tokio = ["futures", "mio", "tokio_02"]
+
 [target."cfg(unix)".dependencies]
+futures = {version = "0.3", optional=true}
 libc = "0.2.69" # .69 added accept4() for NetBSD, Illumos and solaris
 # enabling this feature implements the extension traits for mio-uds types
 mio-uds = {version="0.6", optional=true} # no patch release builds with -Z minimal-versions
@@ -25,7 +29,8 @@ mio_07 = {package="mio", version="0.7.0", features=["os-util", "uds"], optional=
 # examples and tests for mio_07 also requires mio feature os-poll,
 # but adding it as a dev-dependency would also enable it in all cases (cargo bug #4866)
 # instead RUSTFLAGS='--cfg feature="os-poll"' must be used to build & run mio_07 tests
+tokio_02 = {package="tokio", version = "0.2", features = ["io-driver"], optional=true}
 
 [package.metadata.docs.rs]
-features = ["mio-uds", "mio", "mio_07"]
+features = ["mio-uds", "mio", "mio_07", "tokio"]
 rustdoc-args = ["--cfg", "feature=\"os-poll\""]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ mio_07 = {package="mio", version="0.7.0", features=["os-util", "uds"], optional=
 # instead RUSTFLAGS='--cfg feature="os-poll"' must be used to build & run mio_07 tests
 tokio_02 = {package="tokio", version = "0.2", features = ["io-driver"], optional=true}
 
+[target."cfg(unix)".dev-dependencies]
+tokio_02 = {package="tokio", version = "0.2", features = ["macros", "rt-core"]}
+
 [package.metadata.docs.rs]
 features = ["mio-uds", "mio", "mio_07", "tokio"]
 rustdoc-args = ["--cfg", "feature=\"os-poll\""]

--- a/README.md
+++ b/README.md
@@ -88,10 +88,21 @@ Mio 0.7 is also supported:
 uds = {version="0.1.0", features=["mio_07"]}
 ```
 
+## tokio integration
+
+Futures-aware seqpacket types can optionally be used with [tokio](https://github.com/tokio-rs/tokio)
+(version 0.2):
+
+To enable it, add this to Cargo.toml:
+
+```toml
+[dependencies]
+uds = {version="0.1.0", features=["tokio"]}
+```
+
 ## Minimum Rust version
 
-The minimum Rust version is 1.36, because of `std::io::IoSlice`.
-If this is a problem I can make the parts that need it opt-out.
+The minimum Rust version is 1.39.
 
 ## `unsafe` usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ mod helpers;
 mod ancillary;
 mod traits;
 mod seqpacket;
+#[cfg(feature="tokio")]
+pub mod tokio;
 
 pub use addr::{UnixSocketAddr, UnixSocketAddrRef};
 pub use traits::{UnixListenerExt, UnixStreamExt, UnixDatagramExt};

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -1,0 +1,4 @@
+//! Provides support for `SEQPACKET` sockets in Tokio.
+
+mod seqpacket;
+pub use seqpacket::*;

--- a/src/tokio/seqpacket.rs
+++ b/src/tokio/seqpacket.rs
@@ -1,0 +1,96 @@
+use crate::nonblocking;
+use futures::{future::poll_fn, ready};
+use std::io;
+use std::net::Shutdown;
+use std::path::Path;
+use std::task::{Context, Poll};
+use tokio_02::io::PollEvented;
+
+/// An I/O object representing a Unix Sequenced-packet socket.
+pub struct UnixSeqpacketConn {
+    io: PollEvented<nonblocking::UnixSeqpacketConn>,
+}
+
+impl UnixSeqpacketConn {
+    /// Connects to the socket named by path.
+    ///
+    /// This function will create a new Unix socket and connect to the path
+    /// specified, associating the returned stream with the default event loop's
+    /// handle.
+    pub async fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixSeqpacketConn> {
+        let conn = nonblocking::UnixSeqpacketConn::connect(path)?;
+        let conn = UnixSeqpacketConn::from_nonblocking(conn)?;
+
+        poll_fn(|cx| conn.io.poll_write_ready(cx)).await?;
+        Ok(conn)
+    }
+
+    /// Creates a tokio-compatible socket from a nonblocking variant.
+    pub fn from_nonblocking(conn: nonblocking::UnixSeqpacketConn) -> io::Result<UnixSeqpacketConn> {
+        let io = PollEvented::new(conn)?;
+        Ok(UnixSeqpacketConn { io })
+    }
+
+    /// Creates an unnamed pair of connected sockets.
+    ///
+    /// This function will create a pair of interconnected Unix sockets for
+    /// communicating back and forth between one another. Each socket will
+    /// be associated with the default event loop's handle.
+    pub fn pair() -> io::Result<(UnixSeqpacketConn, UnixSeqpacketConn)> {
+        let (a, b) = nonblocking::UnixSeqpacketConn::pair()?;
+        let a = UnixSeqpacketConn::from_nonblocking(a)?;
+        let b = UnixSeqpacketConn::from_nonblocking(b)?;
+
+        Ok((a, b))
+    }
+
+    /// Shuts down the read, write, or both halves of this connection.
+    pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        self.io.get_ref().shutdown(how)
+    }
+}
+
+impl UnixSeqpacketConn {
+    /// Sends data on the socket to the socket's peer.
+    pub async fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
+        poll_fn(|cx| self.poll_send_priv(cx, buf)).await
+    }
+
+    /// Receives data from the socket.
+    pub async fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        poll_fn(|cx| self.poll_recv_priv(cx, buf)).await
+    }
+
+    pub(crate) fn poll_recv_priv(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        ready!(self.io.poll_read_ready(cx, mio::Ready::readable()))?;
+
+        match self.io.get_ref().recv(buf) {
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.io.clear_read_ready(cx, mio::Ready::readable())?;
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+            Ok((x, _truncated)) => Poll::Ready(Ok(x)),
+        }
+    }
+
+    pub(crate) fn poll_send_priv(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        ready!(self.io.poll_write_ready(cx))?;
+
+        match self.io.get_ref().send(buf) {
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.io.clear_write_ready(cx)?;
+                Poll::Pending
+            }
+            x => Poll::Ready(x),
+        }
+    }
+}

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -191,3 +191,33 @@ fn shutdown() {
         assert_eq!(sock_rx.recv(&mut [0u8; 3]).unwrap(), (0, false));
     }
 }
+
+#[cfg(feature="tokio")]
+mod tokio {
+    use std::net::Shutdown;
+    use uds::tokio::UnixSeqpacketConn;
+    use tokio_02 as tokio;
+
+    #[tokio::test]
+    async fn test_conn_pair() {
+        let (mut sock_tx, mut sock_rx) = UnixSeqpacketConn::pair().unwrap();
+
+        tokio::task::spawn(async move {
+            sock_tx.send(&[b'h', b'i', b'0']).await.unwrap();
+        });
+
+        let mut buf = [0u8; 3];
+        let read = sock_rx.recv(&mut buf).await.unwrap();
+        assert_eq!(read, 3);
+        assert_eq!(&buf, &[b'h', b'i', b'0']);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown() {
+        let (mut sock_tx, mut sock_rx) = UnixSeqpacketConn::pair().unwrap();
+
+        sock_tx.shutdown(Shutdown::Both).unwrap();
+        assert!(sock_tx.send(&[b'h', b'i', b'0']).await.is_err());
+        assert_eq!(sock_rx.recv(&mut [0u8; 3]).await.unwrap(), 0);
+    }
+}

--- a/tests/seqpacket.rs
+++ b/tests/seqpacket.rs
@@ -194,9 +194,38 @@ fn shutdown() {
 
 #[cfg(feature="tokio")]
 mod tokio {
+    use std::io;
     use std::net::Shutdown;
-    use uds::tokio::UnixSeqpacketConn;
+    use tempfile::tempdir;
+    use uds::tokio::{UnixSeqpacketConn, UnixSeqpacketListener};
     use tokio_02 as tokio;
+
+    #[tokio::test]
+    async fn test_listener_accept() {
+        let tmp_dir = tempdir().unwrap();
+        let sock_path = tmp_dir.path().join("listener.socket");
+        let mut listener = UnixSeqpacketListener::bind(&sock_path).unwrap();
+
+        let listener_handle = tokio::task::spawn(async move {
+            for i in 1usize..=3 {
+                let (mut socket, _) = listener.accept().await?;
+                tokio::task::spawn(async move {
+                    socket.send(&[b'h', b'i', b'0' + (i as u8)]).await.unwrap();
+                });
+            }
+            Ok::<(), io::Error>(())
+        });
+
+        for i in 1usize..=3 {
+            let mut socket = UnixSeqpacketConn::connect(&sock_path).await.unwrap();
+            let mut buf = [0u8; 3];
+            let read = socket.recv(&mut buf).await.unwrap();
+            assert_eq!(read, 3);
+            assert_eq!(&buf, &[b'h', b'i', b'0' + (i as u8)]);
+        }
+
+        assert!(listener_handle.await.is_ok());
+    }
 
     #[tokio::test]
     async fn test_conn_pair() {

--- a/tests/test_locally.sh
+++ b/tests/test_locally.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-MSRV="1.36.0"
+MSRV="1.39.0"
 
 set -e
 export RUST_BACKTRACE=1
@@ -14,8 +14,10 @@ for target in $check_targets; do
     cargo check --target "$target" --tests --examples --features mio
     cargo check --target "$target" --tests --examples --features mio-uds
     cargo check --target "$target" --features mio_07
+    cargo check --target "$target" --features tokio
     cargo check --target "$target" --all-features
     RUSTFLAGS='--cfg features="os-poll"' cargo check --target "$target" --tests --examples --features mio_07
+    RUSTFLAGS='--cfg features="os-poll"' cargo check --target "$target" --tests --examples --features tokio
     RUSTFLAGS='--cfg features="os-poll"' cargo check --target "$target" --tests --examples --all-features
     echo
 done


### PR DESCRIPTION
Adds dependencies `tokio` + `futures` behind 'tokio' feature.

Implements `tokio::UnixSeqpacketConn` and `tokio::UnixSeqpacketListener` for supporting `SEQPACKET` sockets in Tokio.

Closes #1.

---
Much of this roughly follows how tokio [`UnixStream`](https://docs.rs/tokio/0.2.22/tokio/net/struct.UnixStream.html)/`Listener`s (`SOCK_STREAM`) are set up, but attempts to adopt some of the existing API naming used by `uds`. However, I'm totally open to other naming conventions, or module organization for that matter.

My immediate use-case is for `UnixSeqPacketConn`, but have also introduced (perhaps a bit more roughly) the Listener type for the sake of some sort of completeness.