### PR TITLE
Fix potentially unaligned accesses

### DIFF
--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -135,8 +135,8 @@ pub fn send_ancillary(
                     header.cmsg_type = SCM_RIGHTS;
                     header.cmsg_len = CMSG_LEN(mem::size_of_val(fds) as u32) as ControlLen;
                     let dst = CMSG_DATA(header) as *mut RawFd;
-                    for i in 0..fds.len() {
-                        dst.add(i).write_unaligned(fds[i]);
+                    for (i, &fd) in fds.iter().enumerate() {
+                        dst.add(i).write_unaligned(fd);
                     }
                 }
             }

--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -125,7 +125,7 @@ pub fn send_ancillary(
                         header.cmsg_level = SOL_SOCKET;
                         header.cmsg_type = SCM_CREDENTIALS;
                         header.cmsg_len = CMSG_LEN(mem::size_of_val(&creds) as u32) as ControlLen;
-                        (CMSG_DATA(header) as *mut _).write_unaligned(creds);
+                        (CMSG_DATA(header) as *mut RawReceivedCredentials).write_unaligned(creds);
                         header = &mut*CMSG_NXTHDR(&mut msg, header);
                     }
                 }


### PR DESCRIPTION
The manpage for `CMSG_DATA` specifically states:

>     The
>     pointer returned cannot be assumed to be suitably aligned
>     for accessing arbitrary payload data types.  Applications
>     should not cast it to a pointer type matching the payload,
>     but should instead use memcpy(3) to copy data to or from a
>     suitably declared object.

If this is really needed for 32 bit ints (FDs) is up for debate. But anyway I've opened this PR which

~~1) Returns the FDs in a `Vec` instead of a slice to the fds (one additional allocation and copy, but guaranteed to be safe)~~
2) Checks the size of the `ucred` creds and reads the struct using `read_unaligned`
3) Writes outgoing data using `write_unaligned`