### PR TITLE
Change `as u32` cast to `as c_uint`

### DIFF
--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -226,7 +226,7 @@ impl AncillaryBuf {
                 Self::with_capacity(0)
             } else if num_fds <= max_fds {
                 let payload_bytes = num_fds * mem::size_of::<RawFd>();
-                Self::with_capacity(CMSG_SPACE(payload_bytes as u32) as usize)
+                Self::with_capacity(CMSG_SPACE(payload_bytes as c_uint) as usize)
             } else {
                 panic!("too many file descriptors for ancillary buffer length")
             }


### PR DESCRIPTION
We've bounds checked for `c_uint`, it's possible there will be a platform where this is not `u32`. Fortunately `CSMG_SPACE` also just wants a `c_uint`.