### PR TITLE
feat: add send and recv fns to tokio extension trait

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,29 @@ task:
     - cargo check --features mio_08
     - cargo check --features tokio
   test_script:
-    - cargo test --all-features --no-fail-fast -- --test-threads=1 --nocapture
+    - cargo test --features mio_08,tokio --no-fail-fast -- --test-threads=1 --nocapture
+  before_cache_script:
+    - rm -rf $HOME/.cargo/registry/index
+
+task:
+  name: Linux amd64 1.75
+  container:
+    image: rust:1.75.0
+    cpu: 1
+    memory: 1G # OOMs with 512MB
+  allow_failures: false
+  env:
+    RUST_BACKTRACE: 1
+  cargo_cache:
+    folder: $HOME/.cargo/registry
+    fingerprint_script: cat Cargo.lock 2> /dev/null || true
+  target_cache:
+    folder: target
+    fingerprint_script: cat Cargo.lock 2> /dev/null || true
+  check_script:
+    - cargo check --features tokio,async_trait
+  test_script:
+    - cargo test --features tokio,async_trait --no-fail-fast -- --test-threads=1 --nocapture
   before_cache_script:
     - rm -rf $HOME/.cargo/registry/index
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ categories = ["os::unix-apis", "asynchronous"]
 edition = "2021"
 exclude = ["tests", "src/bin", ".vscode"]
 
+[features]
+mio_08 = [ "dep:mio_08" ]
+tokio = [ "dep:tokio" ]
+async_trait = []
+
 [target."cfg(unix)".dependencies]
 libc = "0.2.90" # peer credentials for DragonFly BSD and NetBSD, SO_PEERSEC on all Linux architectures
 # enabling this feature implements the extension traits for mio 0.8's unix socket types
@@ -26,4 +31,4 @@ tokio = { version = "1.28", features = ["net"], optional=true }
 tokio = { version = "1.28", features = ["io-util", "macros", "rt", 'rt-multi-thread'] }
 
 [package.metadata.docs.rs]
-features = ["mio_08", "tokio"]
+features = ["mio_08", "tokio", "async_trait"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ To enable it, add this to Cargo.toml:
 uds = {version="0.4.2", features=["tokio"]}
 ```
 
+### async
+
+The combination of `tokio` and `async_trait` add async `send` and `recv` methods to the extension trait, in addition to everything already added by the `tokio` feature.
+This increases the minimum Rust version to 1.75.
+
+```toml
+[dependencies]
+uds = {version="0.4.2", features=["tokio", "async_trait"]}
+```
+
 ## Minimum Rust version
 
 The minimum Rust version is 1.63.  


### PR DESCRIPTION
This adds the send and recv fns to the tokio extension trait. Support for this was added in Rust 1.75.0.

This also explicitly adds all features (mio_08, tokio, async_trait) to the Cargo.toml.