### PR TITLE
feat: Mio 1.x.x [fail due to CI rate limiting]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,7 +46,7 @@ task:
     fingerprint_script: cat Cargo.lock 2> /dev/null || true
   check_script:
     - cargo check
-    - cargo check --features mio_08
+    - cargo check --features mio_1xx
     - cargo check --features tokio
   test_script:
     - cargo test --all-features --no-fail-fast -- --test-threads=1 --nocapture
@@ -70,7 +70,7 @@ task:
     - rustc --version
   check_script:
     - cargo check -Z minimal-versions -Z avoid-dev-deps
-    - cargo check -Z minimal-versions -Z avoid-dev-deps --features mio_08
+    - cargo check -Z minimal-versions -Z avoid-dev-deps --features mio_1xx
     - cargo check -Z minimal-versions -Z avoid-dev-deps --features tokio
   # neither -Z minimal-versions nor -Z direct-minimal-versions work with tokio 1
   # and it's a dev-dependency so can't test anything else either

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["tests", "src/bin", ".vscode"]
 libc = "0.2.90" # peer credentials for DragonFly BSD and NetBSD, SO_PEERSEC on all Linux architectures
 # enabling this feature implements the extension traits for mio 0.8's unix socket types
 # and Source for this crate's non-blocking seqpacket types.
-mio_08 = { package = "mio", version = "0.8", features = ["os-ext", "net"], optional = true }
+mio_1xx = { package = "mio", version = "1", features = ["os-ext", "net"], optional = true }
 # .28 for AsyncFd.async_io() helper
 tokio = { version = "1.28", features = ["net"], optional=true }
 
@@ -26,4 +26,4 @@ tokio = { version = "1.28", features = ["net"], optional=true }
 tokio = { version = "1.28", features = ["io-util", "macros", "rt", 'rt-multi-thread'] }
 
 [package.metadata.docs.rs]
-features = ["mio_08", "tokio"]
+features = ["mio_1xx", "tokio"]

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Also, some OSes might return the original file descriptor without cloning it if 
 
 ## mio integration
 
-The `mio_08` feature makes the seqpacket types usable with [mio](https://github.com/tokio-rs/mio) version 0.8 (by implementing its `Source` trait for them),
+The `mio_1xx` feature makes the seqpacket types usable with [mio](https://github.com/tokio-rs/mio) version 0.8 (by implementing its `Source` trait for them),
 and implements this crates extension traits for the unix socket types in [`mio::net`](https://docs.rs/mio/latest/mio/net/index.html).
 
 To enable it, add this to Cargo.toml:
 
 ```toml
 [dependencies]
-uds = {version="0.4.0", features=["mio_08"]}
+uds = {version="0.4.0", features=["mio_1xx"]}
 ```
 
 ## tokio integration

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,7 +21,7 @@ Version 0.4.0 (2023-08-14)
   1.\* support might be implemented later.
 * Remove mio 0.6, mio-uds & mio 0.7 support.
   To simplify code and reduce combinations of features to test.  
-  The feature for mio 0.8 support remains `"mio_08"`: `"mio"` is reserved for mio 1.0.
+  The feature for mio 0.8 support remains `"mio_1xx"`: `"mio"` is reserved for mio 1.0.
 
 Version 0.3.0 (2023-08-14)
 ==========================
@@ -30,7 +30,7 @@ Version 0.3.0 (2023-08-14)
   Use `recv_vectored()` with empty fd buffer if you want to know whether the packet was truncated.
 * Remove default impl of `UnixDatagramExt::bind_unix_addr()`, and remove `Sized` bound on the trait.
 * Stop quoting Unnamed in `UnixSocketaddr`'s `Debug` impl.
-* Add mio_08 feature, for using this library with mio 0.8.
+* Add mio_1xx feature, for using this library with mio 0.8.
 * Require Rust 1.63.
   (Mainly to make CI pass, so older versions will likely work.)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! File-descriptor passing and abstract socket support
 //! for stream and datagram sockets is provided via extension traits for
 //! existing types in `std::os::unix::net` and from [mio](https://github.com/tokio-rs/mio)
-//! (the latter is opt-in and must be enabled with `features=["mio_08"]` in Cargo.toml).
+//! (the latter is opt-in and must be enabled with `features=["mio_1xx"]` in Cargo.toml).
 //!
 //! See README for status of operating system support and other general info.
 
@@ -34,8 +34,8 @@
 )]
 
 extern crate libc;
-#[cfg(feature="mio_08")]
-extern crate mio_08;
+#[cfg(feature="mio_1xx")]
+extern crate mio_1xx;
 #[cfg(feature="tokio")]
 extern crate tokio as tokio_crate;
 

--- a/src/seqpacket.rs
+++ b/src/seqpacket.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use libc::{SOCK_SEQPACKET, MSG_EOR, MSG_PEEK, c_void, close, send, recv};
 
-#[cfg(feature = "mio_08")]
-use mio_08::{event::Source as Source_08, unix::SourceFd as SourceFd_08, Interest as Interest_08, Registry as Registry_08, Token as Token_08};
+#[cfg(feature = "mio_1xx")]
+use mio_1xx::{event::Source as Source_08, unix::SourceFd as SourceFd_08, Interest as Interest_08, Registry as Registry_08, Token as Token_08};
 
 use crate::addr::*;
 use crate::helpers::*;
@@ -43,7 +43,7 @@ macro_rules! impl_rawfd_traits {($type:tt) => {
 
 /// Implements `mio::Evented` and `mio::Source` for a fd-wrapping type.
 macro_rules! impl_mio_if_enabled {($type:tt) => {
-    #[cfg(feature = "mio_08")]
+    #[cfg(feature = "mio_1xx")]
     impl Source_08 for $type {
         fn register(&mut self,  registry: &Registry_08,  token: Token_08,  interest: Interest_08)
         -> Result<(), io::Error> {
@@ -58,7 +58,7 @@ macro_rules! impl_mio_if_enabled {($type:tt) => {
         }
     }
 
-    #[cfg(feature = "mio_08")]
+    #[cfg(feature = "mio_1xx")]
     impl<'a> Source_08 for &'a $type {
         fn register(&mut self,  registry: &Registry_08,  token: Token_08,  interest: Interest_08)
         -> Result<(), io::Error> {
@@ -691,7 +691,7 @@ impl UnixSeqpacketListener {
 /// This type can be used with mio if one of the mio features are enabled:
 ///
 /// ```toml
-/// uds = { version = "x.y", features=["mio_08"] }
+/// uds = { version = "x.y", features=["mio_1xx"] }
 /// ```
 ///
 /// # Examples
@@ -719,11 +719,11 @@ impl UnixSeqpacketListener {
 ///
 /// Registering with mio (v0.8):
 ///
-#[cfg_attr(all(feature="mio_08", not(target_vendor="apple")), doc="```")]
-#[cfg_attr(all(feature="mio_08", target_vendor="apple"), doc="```no_run")]
-#[cfg_attr(not(feature="mio_08"), doc="```no_compile")]
+#[cfg_attr(all(feature="mio_1xx", not(target_vendor="apple")), doc="```")]
+#[cfg_attr(all(feature="mio_1xx", target_vendor="apple"), doc="```no_run")]
+#[cfg_attr(not(feature="mio_1xx"), doc="```no_compile")]
 /// use uds::nonblocking::UnixSeqpacketConn;
-/// use mio_08::{Poll, Events, Token, Interest};
+/// use mio_1xx::{Poll, Events, Token, Interest};
 /// use std::io::ErrorKind;
 ///
 /// let (mut a, b) = UnixSeqpacketConn::pair()
@@ -963,10 +963,10 @@ impl NonblockingUnixSeqpacketConn {
 /// returns non-blocking [connection sockets](struct.NonblockingUnixSeqpacketConn.html)
 /// and doesn't block if no client `connect()`ions are pending.
 ///
-/// This type can be used with mio if the `mio_08` feature is enabled:
+/// This type can be used with mio if the `mio_1xx` feature is enabled:
 ///
 /// ```toml
-/// uds = { version = "x.y", features=["mio_08"] }
+/// uds = { version = "x.y", features=["mio_1xx"] }
 /// ```
 ///
 /// # Examples
@@ -993,11 +993,11 @@ impl NonblockingUnixSeqpacketConn {
 ///
 /// Registering with mio v0.8:
 ///
-#[cfg_attr(all(feature="mio_08", not(target_vendor="apple")), doc="```")]
-#[cfg_attr(all(feature="mio_08", target_vendor="apple"), doc="```no_run")]
-#[cfg_attr(not(feature="mio_08"), doc="```no_compile")]
+#[cfg_attr(all(feature="mio_1xx", not(target_vendor="apple")), doc="```")]
+#[cfg_attr(all(feature="mio_1xx", target_vendor="apple"), doc="```no_run")]
+#[cfg_attr(not(feature="mio_1xx"), doc="```no_compile")]
 /// use uds::nonblocking::{UnixSeqpacketListener, UnixSeqpacketConn};
-/// use mio_08::{Poll, Events, Token, Interest};
+/// use mio_1xx::{Poll, Events, Token, Interest};
 /// use std::io::ErrorKind;
 ///
 /// # let _ = std::fs::remove_file("seqpacket.sock");

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -70,8 +70,8 @@ impl UnixStreamExt for UnixStream {
     }
 }
 
-#[cfg(feature = "mio_08")]
-impl UnixStreamExt for mio_08::net::UnixStream {
+#[cfg(feature = "mio_1xx")]
+impl UnixStreamExt for mio_1xx::net::UnixStream {
     fn connect_to_unix_addr(addr: &UnixSocketAddr) -> Result<Self, io::Error> {
         let socket = Socket::new(SOCK_STREAM, true)?;
         set_unix_addr(socket.as_raw_fd(), SetAddr::PEER, addr)?;
@@ -121,9 +121,9 @@ impl UnixListenerExt for UnixListener {
     }
 }
 
-#[cfg(feature = "mio_08")]
-impl UnixListenerExt for mio_08::net::UnixListener {
-    type Conn = mio_08::net::UnixStream;
+#[cfg(feature = "mio_1xx")]
+impl UnixListenerExt for mio_1xx::net::UnixListener {
+    type Conn = mio_1xx::net::UnixStream;
 
     fn bind_unix_addr(on: &UnixSocketAddr) -> Result<Self, io::Error> {
         let socket = Socket::new(SOCK_STREAM, true)?;
@@ -303,9 +303,9 @@ pub trait UnixDatagramExt: AsRawFd + FromRawFd {
     ///
     /// Read content into a separate buffer than header:
     ///
-    #[cfg_attr(feature="mio_08", doc="```")]
-    #[cfg_attr(not(feature="mio_08"), doc="```no_compile")]
-    /// use mio_08::net::UnixDatagram;
+    #[cfg_attr(feature="mio_1xx", doc="```")]
+    #[cfg_attr(not(feature="mio_1xx"), doc="```no_compile")]
+    /// use mio_1xx::net::UnixDatagram;
     /// use uds::UnixDatagramExt;
     /// use std::io::IoSliceMut;
     ///
@@ -497,10 +497,10 @@ impl UnixDatagramExt for UnixDatagram {
     }
 }
 
-#[cfg(feature = "mio_08")]
-impl UnixDatagramExt for mio_08::net::UnixDatagram {
+#[cfg(feature = "mio_1xx")]
+impl UnixDatagramExt for mio_1xx::net::UnixDatagram {
     fn bind_unix_addr(addr: &UnixSocketAddr) -> Result<Self, io::Error> {
-        match mio_08::net::UnixDatagram::unbound() {
+        match mio_1xx::net::UnixDatagram::unbound() {
             Ok(socket) => match socket.bind_to_unix_addr(addr) {
                 Ok(()) => Ok(socket),
                 Err(e) => Err(e),

--- a/tests/mio.rs
+++ b/tests/mio.rs
@@ -1,7 +1,7 @@
-#![cfg(any(feature = "mio_08"))]
+#![cfg(any(feature = "mio_1xx"))]
 
-#[cfg(feature = "mio_08")]
-extern crate mio_08;
+#[cfg(feature = "mio_1xx")]
+extern crate mio_1xx;
 
 use std::fs::remove_file;
 use std::{io::{Read, Write}, path::Path, time::Duration};
@@ -63,8 +63,8 @@ macro_rules! mio_streams {
     }
 }
 
-#[cfg(feature = "mio_08")]
+#[cfg(feature = "mio_1xx")]
 #[test]
-fn mio_08_stream() {
-    mio_streams!(mio_08);
+fn mio_1xx_stream() {
+    mio_streams!(mio_1xx);
 }

--- a/tests/test_locally.sh
+++ b/tests/test_locally.sh
@@ -43,7 +43,7 @@ done
 echo "checking with minimum version dependencies"
 rm Cargo.lock
 cargo +nightly check $CAFLAGS -Z minimal-versions
-cargo +nightly check $CAFLAGS -Z minimal-versions --features mio_08
+cargo +nightly check $CAFLAGS -Z minimal-versions --features mio_1xx
 cargo +nightly check $CAFLAGS -Z minimal-versions --all-features
 rm Cargo.lock
 echo


### PR DESCRIPTION
Upgrading to mio 1.x.x seems to work without issue at least on my machine. Is there any reason for supporting just 0.8 at the moment?